### PR TITLE
Vagrant上のnginxで4000番使わせるので、ポート番号変えた。

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func rooter(e *echo.Echo) (*echo.Echo){
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 
+
 	dbcon :=  SetDBConnection()
 
 	resource.DB = dbcon
@@ -47,9 +48,9 @@ func rooter(e *echo.Echo) (*echo.Echo){
 func main() {
 	fmt.Println("main")
 	e := rooter(echo.New())
-	fmt.Println("Server running at http://localhost:4000")
+	fmt.Println("Server running at http://localhost:60000")
 	// Start server
-	e.Run(standard.New(":4000"))
+	e.Run(standard.New(":60000"))
 }
 
 


### PR DESCRIPTION
nginxを噛ませてgoのサーバーを動かすために以下の変更を入れました。
- goで使用するポート番号を変更(とりあえず60000番に指定してます。)
- nginx側のポート番号を4000番に

尚、nginxの設定は下記の通り

/etc/nginx/conf.d/default.conf

```
    server {
        listen       4000;
        # listen       80;
        server_name  localhost;

        #charset koi8-r;
        #access_log  /var/log/nginx/log/host.access.log  main;

        location / {
            #root   /usr/share/nginx/html;
            #index  index.html index.htm;
            proxy_pass http://127.0.0.1:60000/;
        }
        ~ 中略 ~
    }
```
